### PR TITLE
Fix mapping of SourceDescription in custom data

### DIFF
--- a/drm-playback/src/SampleReceiver.ts
+++ b/drm-playback/src/SampleReceiver.ts
@@ -65,7 +65,7 @@ export class SampleReceiver {
         }
 
         // Check for sourceDescription
-        const sourceDescription: SourceDescription = loadRequestData?.customData?.sourceDescription;
+        const sourceDescription: SourceDescription = loadRequestData?.customData;
         const selectedSource = sourceDescription?.sources?.find((source: Source) => {
             return source.src === loadRequestData.media.contentId || source.src === loadRequestData.media.contentUrl;
         });


### PR DESCRIPTION
The example is not actually working as the `SourceDescription` object is passed as root object of custom data key - this is the debug payload of load request:
```json
{
   "type":"REQUEST_LOAD",
   "requestData":{
      "currentTime":481.144286,
      "media":{
         "metadata":{
            "title":"<title>",
            "images":[
               {
                  "url":"<url>",
                  "width":0,
                  "height":0
               }
            ],
            "metadataType":0
         },
         "contentId":"<url>",
         "startAbsoluteTime":0,
         "contentType":"application/dash+xml",
         "streamType":"BUFFERED",
         "duration":0
      },
      "customData":{
         "metadata":{
            "title":"<title>"
         },
         "poster":"<url>",
         "textTracks":[
            
         ],
         "sources":[
            {
               "crossOrigin":null,
               "contentProtection":{
                  "headers":[
                     {
                        "X-AxDRM-Message":"<token>"
                     }
                  ],
                  "widevine":{
                     "licenseAcquisitionURL":"<url>",
                     "headers":{
                        "X-AxDRM-Message":"<token>"
                     }
                  }
               },
               "type":"application/dash+xml",
               "src":"<url>",
               "hlsDateRange":null
            }
         ]
      },
      "autoplay":false,
      "type":"LOAD",
      "requestId":4,
      "playbackRate":1
   },
   "senderId":"<id>"
}
```

The original code expects the source description to be placed inside `sourceDescription` key of `customData` object, but THEOplayer sends that in the root. Because of that the source description is always undefined.

This PR just fixes that.